### PR TITLE
feat(measurement): WebSearch 호출 카운트 측정 인프라

### DIFF
--- a/docs/measurement/websearch-tracking.md
+++ b/docs/measurement/websearch-tracking.md
@@ -1,0 +1,109 @@
+# WebSearch 호출 카운트 측정
+
+stock skill **v8.b** 부터 운영. WebSearch 의존도 감축 (도입 전 추정 17~50회/일 → 도입 후 1주 평균) 정량 비교용 인프라.
+
+## 1. 로그 파일
+
+- 경로: `agent/_search_log.jsonl` (이 디렉토리 자체가 `.gitignore` — **commit 금지**)
+- 포맷: JSONL (1줄 = 1 호출)
+- append-only — LLM 이 WebSearch 를 호출할 때마다 1줄씩 추가
+
+## 2. 1줄 스키마
+
+| 필드 | 타입 | 예시 | 설명 |
+|---|---|---|---|
+| `date` | string (`YYYY-MM-DD`) | `"2026-05-03"` | ISO 날짜 |
+| `timestamp` | string (ISO 8601) | `"2026-05-03T09:30:15+09:00"` | 호출 시각 (TZ 포함) |
+| `scope` | enum | `"stock"` | `stock` / `economy_base` / `industry_base` / `stock_base` / `macro` |
+| `code_or_market` | string | `"005930"` / `"kr"` / `"semiconductor"` | 종목 코드 / 시장 / 산업 코드 |
+| `trigger` | string | `"earnings_d7"` | `manual` / `stale_disclosures_empty` / `stale_in_industry_5dim` / `earnings_d7` / `52w_break` / ... (오픈셋) |
+| `query` | string | `"삼성전자 1Q 가이던스"` | 실제 WebSearch 쿼리 |
+| `cached` | bool | `false` | 같은 분 내 동일 쿼리 재사용이면 `true` |
+
+7개 필드 **모두 필수** — 누락된 row 는 집계 시 skip 처리.
+
+### 예시 (1줄)
+
+```json
+{"date":"2026-05-03","timestamp":"2026-05-03T09:30:15+09:00","scope":"stock","code_or_market":"005930","trigger":"earnings_d7","query":"삼성전자 1Q 가이던스","cached":false}
+```
+
+## 3. 집계 명령
+
+```bash
+# default: agent/_search_log.jsonl, 최근 7일, scope 별 분포
+python scripts/measure_websearch.py
+
+# 14일 윈도, trigger 별 분포
+python scripts/measure_websearch.py --days 14 --by trigger
+
+# 다른 경로
+python scripts/measure_websearch.py --input path/to/log.jsonl --days 30 --by scope
+```
+
+CLI 인자:
+
+| 인자 | 기본값 | 설명 |
+|---|---|---|
+| `--input` | `agent/_search_log.jsonl` | jsonl 경로 |
+| `--days` | `7` | 집계 윈도 (anchor = log 내 max(date)) |
+| `--by` | `scope` | 분포 표 그룹키 (`scope` / `trigger`) |
+
+stdlib (argparse + json + collections + datetime) 만 사용 — 외부 의존성 추가 X.
+
+## 4. 출력 예시
+
+```
+============================================================
+WebSearch 호출 집계
+============================================================
+input  : agent/_search_log.jsonl
+window : last 7 day(s) (anchor = max(date) in log)
+rows   : 35  (skipped malformed: 0)
+avg/day: 5.00
+cached : 14.3%
+
+## Baseline 비교 (운영 전 추정 17~50회/일)
+  vs 17/day  →  reduction  +70.6%
+  vs 50/day  →  reduction  +90.0%
+
+## 일별 호출 수
+  2026-04-27     6  ( 17.1%)
+  2026-04-28     5  ( 14.3%)
+  ...
+
+## scope 별 분포
+  stock              18  ( 51.4%)
+  industry_base       8  ( 22.9%)
+  economy_base        5  ( 14.3%)
+  stock_base          3  (  8.6%)
+  macro               1  (  2.9%)
+```
+
+`reduction` 양수=감축, 음수=baseline 초과.
+
+## 5. 운영 가이드 (LLM 용)
+
+WebSearch 호출 직후 (즉시) 1줄 append:
+
+1. `scope` — 어느 워크플로우 단위에서 호출했는지 (stock 1건 분석이면 `"stock"`)
+2. `code_or_market` — 분석 대상 식별자
+3. `trigger` — **왜** 이 호출이 필요했는지 (manual = 사용자 명시 요청 / 나머지 = 자동 트리거 사유)
+4. `cached` — 같은 분(`HH:MM`) 내 동일 query 가 이미 있으면 `true`, 아니면 `false`
+
+trigger 명명 가이드 (오픈셋이지만 일관성 유지):
+
+- `manual` — 사용자 직접 요청
+- `stale_disclosures_empty` — 공시 데이터 비어 있어 보강
+- `stale_in_industry_5dim` — 산업 5차원 지표 stale
+- `earnings_d7` — 실적 발표 D-7 이내
+- `52w_break` — 52주 신고/신저 돌파
+- 기타 — `<sensor>_<reason>` 형태로 신설 가능
+
+## 6. 테스트
+
+```bash
+pytest tests/test_measure_websearch.py
+```
+
+합성 jsonl 7 row + malformed 케이스 + CLI smoke 16개 테스트.

--- a/scripts/measure_websearch.py
+++ b/scripts/measure_websearch.py
@@ -1,0 +1,248 @@
+"""WebSearch 호출 카운트 집계 스크립트.
+
+LLM 이 stock/economy_base/industry_base/stock_base/macro 워크플로우에서
+WebSearch 를 호출할 때마다 ``agent/_search_log.jsonl`` 에 1줄씩 append 하면,
+이 스크립트가 일별/스코프별/트리거별 분포 + 캐시 비율 + baseline 감축률을 출력한다.
+
+운영 시점은 stock skill v8.b — 그 이전엔 baseline (17~50회/일, 추정) 만 존재.
+
+JSONL 1줄 schema (필드 전부 필수)::
+
+    {
+      "date":           "YYYY-MM-DD",                     // ISO 날짜
+      "timestamp":      "YYYY-MM-DDTHH:MM:SS+09:00",      // ISO 8601
+      "scope":          "stock" | "economy_base" | "industry_base" | "stock_base" | "macro",
+      "code_or_market": "005930" | "kr" | "us" | "semiconductor" | "global",
+      "trigger":        "manual" | "stale_disclosures_empty" | "stale_in_industry_5dim"
+                        | "earnings_d7" | "52w_break" | ...,
+      "query":          "<실제 WebSearch 쿼리 문자열>",
+      "cached":         true | false                      // 같은 분 내 동일 query 재사용 여부
+    }
+
+사용 예::
+
+    python scripts/measure_websearch.py                                  # default 7d, by=scope
+    python scripts/measure_websearch.py --days 14 --by trigger
+    python scripts/measure_websearch.py --input some/other/path.jsonl
+
+외부 라이브러리 의존성 없음 — Python stdlib (argparse + json + collections + datetime) 만 사용.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter, defaultdict
+from datetime import date, datetime, timedelta
+from pathlib import Path
+from typing import Any, Iterable
+
+# ---------------------------------------------------------------------------
+# 상수
+# ---------------------------------------------------------------------------
+
+DEFAULT_INPUT = "agent/_search_log.jsonl"
+DEFAULT_DAYS = 7
+DEFAULT_BY = "scope"
+
+#: stock skill 도입 전 추정 baseline (회/일). plan 문서 v8.b 기준.
+BASELINE_LOW = 17
+BASELINE_HIGH = 50
+
+REQUIRED_FIELDS = ("date", "timestamp", "scope", "code_or_market", "trigger", "query", "cached")
+
+VALID_SCOPES = {"stock", "economy_base", "industry_base", "stock_base", "macro"}
+
+
+# ---------------------------------------------------------------------------
+# 파싱
+# ---------------------------------------------------------------------------
+
+
+def parse_log(path: Path) -> tuple[list[dict[str, Any]], int]:
+    """JSONL 파일을 읽어 row list + 스킵된 (malformed) 라인 수를 반환."""
+    rows: list[dict[str, Any]] = []
+    skipped = 0
+    if not path.exists():
+        return rows, skipped
+    with path.open("r", encoding="utf-8") as f:
+        for raw in f:
+            line = raw.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError:
+                skipped += 1
+                continue
+            if not isinstance(obj, dict):
+                skipped += 1
+                continue
+            if not all(k in obj for k in REQUIRED_FIELDS):
+                skipped += 1
+                continue
+            rows.append(obj)
+    return rows, skipped
+
+
+def _row_date(row: dict[str, Any]) -> date | None:
+    """row['date'] 를 ``date`` 로 파싱. 실패 시 None."""
+    try:
+        return datetime.strptime(str(row["date"]), "%Y-%m-%d").date()
+    except (ValueError, KeyError):
+        return None
+
+
+def filter_recent(rows: Iterable[dict[str, Any]], days: int) -> list[dict[str, Any]]:
+    """가장 최근 date 를 anchor 로 마지막 ``days`` 일 (inclusive) 의 row 만 남긴다.
+
+    today 기반이 아니라 log 내 max(date) 기반 — 오프라인/지연 로그도 결정적으로 처리.
+    """
+    parsed: list[tuple[date, dict[str, Any]]] = []
+    for row in rows:
+        d = _row_date(row)
+        if d is None:
+            continue
+        parsed.append((d, row))
+    if not parsed:
+        return []
+    anchor = max(d for d, _ in parsed)
+    cutoff = anchor - timedelta(days=days - 1)
+    return [row for d, row in parsed if cutoff <= d <= anchor]
+
+
+# ---------------------------------------------------------------------------
+# 집계
+# ---------------------------------------------------------------------------
+
+
+def aggregate_by_date(rows: Iterable[dict[str, Any]]) -> dict[str, int]:
+    counter: Counter[str] = Counter()
+    for row in rows:
+        counter[str(row["date"])] += 1
+    return dict(sorted(counter.items()))
+
+
+def aggregate_by_field(rows: Iterable[dict[str, Any]], field: str) -> dict[str, int]:
+    counter: Counter[str] = Counter()
+    for row in rows:
+        counter[str(row.get(field, "<missing>"))] += 1
+    return dict(counter.most_common())
+
+
+def cached_ratio(rows: list[dict[str, Any]]) -> float:
+    """cached=True 비율 (0.0 ~ 1.0). row 가 없으면 0.0."""
+    if not rows:
+        return 0.0
+    hits = sum(1 for r in rows if bool(r.get("cached")))
+    return hits / len(rows)
+
+
+def avg_daily(rows: list[dict[str, Any]], days: int) -> float:
+    """``days`` 윈도 기준 평균 호출 수 (총합 / days). days <= 0 이면 0.0."""
+    if days <= 0:
+        return 0.0
+    return len(rows) / days
+
+
+def reduction_rate(avg: float, baseline: float) -> float:
+    """baseline 대비 감축률 (양수=감소, 음수=baseline 초과). baseline<=0 이면 0.0."""
+    if baseline <= 0:
+        return 0.0
+    return (baseline - avg) / baseline
+
+
+# ---------------------------------------------------------------------------
+# 리포트 포매팅
+# ---------------------------------------------------------------------------
+
+
+def _format_table(title: str, mapping: dict[str, int], total: int) -> list[str]:
+    if not mapping:
+        return [f"## {title}", "  (empty)", ""]
+    lines = [f"## {title}"]
+    width = max(len(k) for k in mapping)
+    for k, v in mapping.items():
+        pct = (v / total * 100) if total else 0.0
+        lines.append(f"  {k.ljust(width)}  {v:>4}  ({pct:5.1f}%)")
+    lines.append("")
+    return lines
+
+
+def format_report(
+    rows: list[dict[str, Any]],
+    days: int,
+    by: str,
+    skipped: int,
+    input_path: Path,
+) -> str:
+    by_date = aggregate_by_date(rows)
+    by_field = aggregate_by_field(rows, by)
+    total = len(rows)
+    avg = avg_daily(rows, days)
+    cached_pct = cached_ratio(rows) * 100
+    red_low = reduction_rate(avg, BASELINE_LOW) * 100
+    red_high = reduction_rate(avg, BASELINE_HIGH) * 100
+
+    lines: list[str] = []
+    lines.append("=" * 60)
+    lines.append("WebSearch 호출 집계")
+    lines.append("=" * 60)
+    lines.append(f"input  : {input_path}")
+    lines.append(f"window : last {days} day(s) (anchor = max(date) in log)")
+    lines.append(f"rows   : {total}  (skipped malformed: {skipped})")
+    lines.append(f"avg/day: {avg:.2f}")
+    lines.append(f"cached : {cached_pct:.1f}%")
+    lines.append("")
+    lines.append("## Baseline 비교 (운영 전 추정 17~50회/일)")
+    lines.append(f"  vs {BASELINE_LOW:>2}/day  →  reduction { red_low:+6.1f}%")
+    lines.append(f"  vs {BASELINE_HIGH:>2}/day  →  reduction { red_high:+6.1f}%")
+    lines.append("")
+    lines.extend(_format_table("일별 호출 수", by_date, total))
+    lines.extend(_format_table(f"{by} 별 분포", by_field, total))
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="measure_websearch",
+        description="WebSearch 호출 로그 (_search_log.jsonl) 집계.",
+    )
+    p.add_argument("--input", default=DEFAULT_INPUT, help=f"jsonl 경로 (default: {DEFAULT_INPUT})")
+    p.add_argument(
+        "--days",
+        type=int,
+        default=DEFAULT_DAYS,
+        help=f"집계 윈도 (일, default: {DEFAULT_DAYS})",
+    )
+    p.add_argument(
+        "--by",
+        choices=("scope", "trigger"),
+        default=DEFAULT_BY,
+        help=f"분포 표 그룹키 (default: {DEFAULT_BY})",
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if args.days <= 0:
+        print("error: --days must be a positive integer", file=sys.stderr)
+        return 2
+    path = Path(args.input)
+    rows, skipped = parse_log(path)
+    if not path.exists():
+        print(f"warn: {path} not found — empty report", file=sys.stderr)
+    windowed = filter_recent(rows, args.days)
+    print(format_report(windowed, args.days, args.by, skipped, path))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/test_measure_websearch.py
+++ b/tests/test_measure_websearch.py
@@ -1,0 +1,203 @@
+"""scripts/measure_websearch.py 집계 검증.
+
+실행: ``pytest tests/test_measure_websearch.py``
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import measure_websearch as m  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# fixtures
+# ---------------------------------------------------------------------------
+
+
+def _row(date: str, scope: str, trigger: str, cached: bool = False, **extra) -> dict:
+    base = {
+        "date": date,
+        "timestamp": f"{date}T09:30:00+09:00",
+        "scope": scope,
+        "code_or_market": extra.pop("code_or_market", "kr"),
+        "trigger": trigger,
+        "query": extra.pop("query", "test query"),
+        "cached": cached,
+    }
+    base.update(extra)
+    return base
+
+
+@pytest.fixture
+def synthetic_rows() -> list[dict]:
+    # 7개 row, 3개 날짜, 3개 scope, 2개 trigger, cached 2개
+    return [
+        _row("2026-05-01", "stock", "manual", cached=False),
+        _row("2026-05-01", "stock", "earnings_d7", cached=True),
+        _row("2026-05-02", "economy_base", "manual", cached=False),
+        _row("2026-05-02", "industry_base", "stale_in_industry_5dim", cached=False),
+        _row("2026-05-02", "stock", "52w_break", cached=True),
+        _row("2026-05-03", "stock_base", "stale_disclosures_empty", cached=False),
+        _row("2026-05-03", "macro", "manual", cached=False),
+    ]
+
+
+@pytest.fixture
+def jsonl_file(tmp_path: Path, synthetic_rows: list[dict]) -> Path:
+    path = tmp_path / "log.jsonl"
+    with path.open("w", encoding="utf-8") as f:
+        for row in synthetic_rows:
+            f.write(json.dumps(row, ensure_ascii=False) + "\n")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# parse_log
+# ---------------------------------------------------------------------------
+
+
+def test_parse_log_reads_all_rows(jsonl_file: Path):
+    rows, skipped = m.parse_log(jsonl_file)
+    assert len(rows) == 7
+    assert skipped == 0
+
+
+def test_parse_log_skips_malformed(tmp_path: Path):
+    path = tmp_path / "broken.jsonl"
+    good = json.dumps(
+        {
+            "date": "2026-05-01",
+            "timestamp": "2026-05-01T09:00:00+09:00",
+            "scope": "stock",
+            "code_or_market": "005930",
+            "trigger": "manual",
+            "query": "q",
+            "cached": False,
+        }
+    )
+    path.write_text(
+        "\n".join([good, "{not json", json.dumps({"missing": "fields"}), "", good]) + "\n",
+        encoding="utf-8",
+    )
+    rows, skipped = m.parse_log(path)
+    assert len(rows) == 2
+    assert skipped == 2  # invalid JSON + missing-field row (blank line is just skipped)
+
+
+def test_parse_log_missing_file(tmp_path: Path):
+    rows, skipped = m.parse_log(tmp_path / "nope.jsonl")
+    assert rows == []
+    assert skipped == 0
+
+
+# ---------------------------------------------------------------------------
+# filter_recent
+# ---------------------------------------------------------------------------
+
+
+def test_filter_recent_window_inclusive(synthetic_rows: list[dict]):
+    # max date = 2026-05-03; days=2 → keep 05-02 and 05-03
+    out = m.filter_recent(synthetic_rows, days=2)
+    assert {r["date"] for r in out} == {"2026-05-02", "2026-05-03"}
+    assert len(out) == 5
+
+
+def test_filter_recent_full_window(synthetic_rows: list[dict]):
+    out = m.filter_recent(synthetic_rows, days=7)
+    assert len(out) == 7
+
+
+def test_filter_recent_empty():
+    assert m.filter_recent([], days=7) == []
+
+
+# ---------------------------------------------------------------------------
+# 집계
+# ---------------------------------------------------------------------------
+
+
+def test_aggregate_by_date(synthetic_rows: list[dict]):
+    out = m.aggregate_by_date(synthetic_rows)
+    assert out == {"2026-05-01": 2, "2026-05-02": 3, "2026-05-03": 2}
+    assert list(out.keys()) == sorted(out.keys())  # 정렬 보장
+
+
+def test_aggregate_by_scope(synthetic_rows: list[dict]):
+    out = m.aggregate_by_field(synthetic_rows, "scope")
+    assert out["stock"] == 3
+    assert out["economy_base"] == 1
+    assert out["industry_base"] == 1
+    assert out["stock_base"] == 1
+    assert out["macro"] == 1
+    assert sum(out.values()) == 7
+
+
+def test_aggregate_by_trigger(synthetic_rows: list[dict]):
+    out = m.aggregate_by_field(synthetic_rows, "trigger")
+    assert out["manual"] == 3
+    assert out["earnings_d7"] == 1
+    assert out["52w_break"] == 1
+    assert sum(out.values()) == 7
+
+
+def test_cached_ratio(synthetic_rows: list[dict]):
+    # 2 of 7
+    assert m.cached_ratio(synthetic_rows) == pytest.approx(2 / 7)
+
+
+def test_cached_ratio_empty():
+    assert m.cached_ratio([]) == 0.0
+
+
+def test_avg_daily(synthetic_rows: list[dict]):
+    assert m.avg_daily(synthetic_rows, days=7) == pytest.approx(1.0)
+    assert m.avg_daily(synthetic_rows, days=1) == pytest.approx(7.0)
+    assert m.avg_daily([], days=7) == 0.0
+    assert m.avg_daily(synthetic_rows, days=0) == 0.0
+
+
+def test_reduction_rate():
+    # baseline 50, avg 25 → 50% 감축
+    assert m.reduction_rate(25.0, 50.0) == pytest.approx(0.5)
+    # baseline 17, avg 17 → 0%
+    assert m.reduction_rate(17.0, 17.0) == pytest.approx(0.0)
+    # baseline 17, avg 34 → -100% (baseline 초과)
+    assert m.reduction_rate(34.0, 17.0) == pytest.approx(-1.0)
+    assert m.reduction_rate(10.0, 0.0) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# 리포트 / CLI
+# ---------------------------------------------------------------------------
+
+
+def test_format_report_contains_sections(synthetic_rows: list[dict]):
+    out = m.format_report(synthetic_rows, days=7, by="scope", skipped=0, input_path=Path("x.jsonl"))
+    assert "WebSearch 호출 집계" in out
+    assert "일별 호출 수" in out
+    assert "scope 별 분포" in out
+    assert "Baseline 비교" in out
+    assert "2026-05-01" in out
+    assert "stock" in out
+
+
+def test_main_smoke(jsonl_file: Path, capsys):
+    rc = m.main(["--input", str(jsonl_file), "--days", "7", "--by", "trigger"])
+    assert rc == 0
+    captured = capsys.readouterr().out
+    assert "trigger 별 분포" in captured
+    assert "manual" in captured
+    assert "rows   : 7" in captured
+
+
+def test_main_rejects_bad_days(tmp_path: Path, capsys):
+    rc = m.main(["--input", str(tmp_path / "x.jsonl"), "--days", "0"])
+    assert rc == 2


### PR DESCRIPTION
## Summary
- `agent/_search_log.jsonl` 1줄 schema (7 필드) 정립 + LLM 운영 가이드 (`docs/measurement/websearch-tracking.md`)
- `scripts/measure_websearch.py` — 일별 호출 수 / scope·trigger 분포 / cached 비율 / baseline(17~50/day) 감축률 집계 (stdlib only)
- `tests/test_measure_websearch.py` — 16 케이스 (parse · filter · aggregate · cached · reduction · format · CLI smoke)
- `agent/_search_log.jsonl` 자체는 `.gitignore` 처리되어 있어 commit 하지 않음 — 코드 + docstring 으로만 형식 명시

v8.b 운영 시작 시 사용. baseline (현 plan 추정 17~50회/일) vs 도입 후 1주 평균 비교용.

## Test plan
- [x] `pytest tests/test_measure_websearch.py` → 16 passed (Python 3.14)
- [x] CLI smoke: `python scripts/measure_websearch.py --input <sample>.jsonl` → 표 포맷 확인
- [x] malformed jsonl 라인 skip 동작 확인
- [x] `--days 0` 거부 (rc=2)

## 사용 예시

```bash
# default (agent/_search_log.jsonl, last 7d, by scope)
python scripts/measure_websearch.py

# 14일 윈도, trigger 별 분포
python scripts/measure_websearch.py --days 14 --by trigger
```

출력 예시 일부:

```
rows   : 35  (skipped malformed: 0)
avg/day: 5.00
cached : 14.3%

## Baseline 비교 (운영 전 추정 17~50회/일)
  vs 17/day  →  reduction  +70.6%
  vs 50/day  →  reduction  +90.0%

## scope 별 분포
  stock              18  ( 51.4%)
  industry_base       8  ( 22.9%)
  ...
```

## 후속 작업 (이 PR 범위 밖)
- skill 절차서 (per-stock-analysis / base-* references) 에 "WebSearch 호출 직후 1줄 append" 가이드 삽입 — v8.b 운영 시작 시 함께 진행

🤖 Generated with [Claude Code](https://claude.com/claude-code)